### PR TITLE
fix: Allow to access nested attributes in templates via recursive JSON map for attributes

### DIFF
--- a/include/spore/codegen/ast/converters/ast_converter_default.hpp
+++ b/include/spore/codegen/ast/converters/ast_converter_default.hpp
@@ -70,7 +70,13 @@ namespace spore::codegen
 
         for (const ast_attribute& attribute : value)
         {
-            json[attribute.full_name()] = attribute;
+            std::string json_path = attribute.full_name();
+            json_path.insert(json_path.begin(), '/');
+
+            spore::codegen::replace_all(json_path, "::", "/");
+
+            nlohmann::json::json_pointer json_ptr(json_path);
+            json[json_ptr] = attribute;
         }
     }
 
@@ -84,7 +90,7 @@ namespace spore::codegen
     void to_json(nlohmann::json& json, const ast_template_param& value)
     {
         std::uint32_t unique_id = details::make_unique_id();
-        
+
         json["id"] = unique_id;
         json["name"] = value.name.empty() ? fmt::format("_{}", unique_id) : value.name;
         json["type"] = value.type;
@@ -160,6 +166,7 @@ namespace spore::codegen
     {
         to_json(json, static_cast<const ast_has_name<ast_enum>&>(value));
         to_json(json, static_cast<const ast_has_attributes<ast_enum>&>(value));
+
         json["id"] = details::make_unique_id();
         json["enum_values"] = value.enum_values;
     }

--- a/include/spore/codegen/codegen_helpers.hpp
+++ b/include/spore/codegen/codegen_helpers.hpp
@@ -80,4 +80,14 @@ namespace spore::codegen
     {
         return string.size() >= suffix.size() && 0 == string.compare(string.size() - suffix.size(), suffix.size(), suffix);
     }
+
+    void replace_all(std::string& str, const std::string& from, const std::string& to)
+    {
+        size_t start_pos = 0;
+        while ((start_pos = str.find(from, start_pos)) != std::string::npos)
+        {
+            str.replace(start_pos, from.length(), to);
+            start_pos += to.length();
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/sporacid/spore-codegen/issues/29