### PR TITLE
Add support is optional types

### DIFF
--- a/examples/json/CMakeLists.txt
+++ b/examples/json/CMakeLists.txt
@@ -37,4 +37,5 @@ target_link_libraries(
 
 spore_codegen(
   ${SPORE_CODEGEN_EXAMPLES_JSON_TARGET}
+  DUMP_AST "${CMAKE_CURRENT_SOURCE_DIR}/.dumps"
 )

--- a/examples/json/include/json_types.hpp
+++ b/examples/json/include/json_types.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-
+#include <optional>
 namespace spore::codegen::examples::json
 {
     struct [[json]] generic_pair
@@ -9,6 +9,7 @@ namespace spore::codegen::examples::json
         [[json(name = "Key")]] std::string key;
         [[json(name = "Value")]] std::string value;
         [[json(ignore)]] std::uint32_t version = 0;
+        std::optional<int> opt;
     };
 
     template <typename value_t>

--- a/examples/json/include/json_types.hpp
+++ b/examples/json/include/json_types.hpp
@@ -9,7 +9,7 @@ namespace spore::codegen::examples::json
         [[json(name = "Key")]] std::string key;
         [[json(name = "Value")]] std::string value;
         [[json(ignore)]] std::uint32_t version = 0;
-        std::optional<int> opt;
+        std::optional<int> optional_field;
     };
 
     template <typename value_t>

--- a/include/spore/codegen/ast/ast_field.hpp
+++ b/include/spore/codegen/ast/ast_field.hpp
@@ -15,5 +15,6 @@ namespace spore::codegen
         std::string name;
         std::optional<std::string> default_value;
         ast_ref type;
+        bool is_optional;
     };
 }

--- a/include/spore/codegen/ast/converters/ast_converter_default.hpp
+++ b/include/spore/codegen/ast/converters/ast_converter_default.hpp
@@ -138,6 +138,7 @@ namespace spore::codegen
         json["id"] = details::make_unique_id();
         json["name"] = value.name;
         json["type"] = value.type;
+        json["is_optional"] = value.is_optional;
     }
 
     void to_json(nlohmann::json& json, const ast_class& value)

--- a/include/spore/codegen/ast/parsers/ast_parser_cppast.hpp
+++ b/include/spore/codegen/ast/parsers/ast_parser_cppast.hpp
@@ -268,6 +268,13 @@ namespace spore::codegen
             {
                 const auto& template_ = static_cast<const cppast::cpp_template_instantiation_type&>(cpp_type).primary_template();
 
+                // check for direct instantiation of std::optional
+                if (template_.name() == "std::optional")
+                {
+                    return true;
+                }
+
+                // check for alised std::optional
                 for (const auto& id : template_.id())
                 {
                     if (context.optional_type_ids.find(id.value_) != context.optional_type_ids.end())

--- a/tests/t_ast_parser.cpp
+++ b/tests/t_ast_parser.cpp
@@ -39,9 +39,11 @@ TEMPLATE_TEST_CASE("spore::codegen::ast_parser", "[spore::codegen][spore::codege
 
     SECTION("parse include is feature complete")
     {
-        REQUIRE(file.includes.size() == 1);
+        REQUIRE(file.includes.size() == 2);
         REQUIRE(file.includes[0].type == spore::codegen::ast_include_type::system);
         REQUIRE(file.includes[0].name == "string");
+        REQUIRE(file.includes[1].type == spore::codegen::ast_include_type::system);
+        REQUIRE(file.includes[1].name == "optional");
         REQUIRE_FALSE(file.includes[0].path.empty());
     }
 
@@ -92,7 +94,7 @@ TEMPLATE_TEST_CASE("spore::codegen::ast_parser", "[spore::codegen][spore::codege
 
         SECTION("parse class field is feature complete")
         {
-            REQUIRE(class_.fields.size() == 2);
+            REQUIRE(class_.fields.size() == 4);
 
             REQUIRE(class_.fields[0].name == "_i");
             REQUIRE(class_.fields[0].type.name == "int");
@@ -104,6 +106,14 @@ TEMPLATE_TEST_CASE("spore::codegen::ast_parser", "[spore::codegen][spore::codege
             REQUIRE(class_.fields[1].name == "_s");
             REQUIRE(class_.fields[1].type.name == "std::string");
             // REQUIRE(class_.fields[1].scope == "class_.full_name()");
+
+            REQUIRE(class_.fields[2].name == "_opt");
+            REQUIRE(class_.fields[2].type.name == "std::optional<int>");
+            REQUIRE(class_.fields[2].is_optional == true);
+
+            REQUIRE(class_.fields[3].name == "_opt_alias");
+            REQUIRE(class_.fields[3].type.name == "optional_alias_t<int>");
+            REQUIRE(class_.fields[3].is_optional == true);
         }
 
         SECTION("parse class constructor is feature complete")

--- a/tests/t_ast_parser_input.hpp
+++ b/tests/t_ast_parser_input.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <string>
+#include <optional>
 
 namespace _namespace1::_namespace2
 {
+  template <typename T>
+  using optional_alias_t = std::optional<T>;
+
     enum class [[_enum_attribute(key1 = value1, key2)]] _enum {
         _value1 [[_enum_value_attribute]],
         _value2 = 42,
@@ -17,6 +21,8 @@ namespace _namespace1::_namespace2
     {
         [[_field_attribute]] int _i = 42;
         std::string _s;
+        std::optional<int> _opt;
+        optional_alias_t<int> _opt_alias;
 
         _struct() = default;
 


### PR DESCRIPTION
This is another exploratory PR with the purpose of supporting a `is_optional` flag on the `ast_field` entity so that a template can take specific action for types that are either direct or aliased instantiations of std::optional.

The use case is generating more efficient json codecs for types that have many optionals.
The current example template will always write `"key":null` for all nullopts, which becomes wasteful on the wire.
It's also an issue when we're dealing with conversion from json for configuration files as this would also require the user to manually specify all optional fields as null.

The template could do a `contains` check for every field but this would silently fail if the user does not set a required field (which should actually throw on the call to `at()`).

Another alternative would be a `[[json(optional)]]` attribute but this quickly becomes a problem on large codebases as it's really easy to forget to add the attribute and this will be a difficult bug to track. 
It is even easier to forget if the type in the class is an alias and not directly a `std::optional`, for example: 

```cpp
# A.hpp
using my_type_t = std::optional<int>;

# B.hpp
struct my_struct
{
  my_type_t mt; // not clear that this is optional
};
```

Sample usage in template and the code it generates:

```
  {% for field in class.fields %}
      {% if not truthy(field.attributes, "json.values.ignore") %}
          {% if truthy(field.is_optional) %}
            if (value.{{ field.name }}.has_value()) {
          {% endif %}
          {% if truthy(field.attributes, "json.values.name") %}
              json["{{ field.attributes.json.values.name }}"] = value.{{ field.name }};
          {% else %}
              json["{{ field.name }}"] = value.{{ field.name }};
          {% endif %}
          {% if truthy(field.is_optional) %}
            }
          {% endif %}
      {% endif %}
  {% endfor %}
```

```cpp
inline void to_json([[maybe_unused]] nlohmann::json& json, [[maybe_unused]] const test_struct& value)
{
...
  if (value.m_optional_string_value.has_value()) {
    json["m_optional_string_value"] = value.m_optional_string_value;
  }
  if (value.m_optional_string_null.has_value()) {
    json["m_optional_string_null"] = value.m_optional_string_null;
  }
...
}

inline void from_json([[maybe_unused]] const nlohmann::json& json, [[maybe_unused]] test_struct& value)
{
...
  if (json.contains("m_optional_string_value")) {
    json.at("m_optional_string_value").get_to(value.m_optional_string_value);
  }
  if (json.contains("m_optional_string_null")) {
    json.at("m_optional_string_null").get_to(value.m_optional_string_null);
  }
...
}
```