### PR TITLE
fix: Fix unnamed template parameters name

### DIFF
--- a/include/spore/codegen/ast/ast_name.hpp
+++ b/include/spore/codegen/ast/ast_name.hpp
@@ -35,7 +35,14 @@ namespace spore::codegen
                     {
                         for (const ast_template_param& template_param : has_template_params.template_params)
                         {
-                            full_name += template_param.name + ", ";
+                            full_name += template_param.name;
+
+                            if (template_param.is_variadic)
+                            {
+                                full_name += "...";
+                            }
+
+                            full_name += ", ";
                         }
                     }
                     else if (has_template_params.is_template_specialization())

--- a/include/spore/codegen/ast/parsers/ast_parser_clang.hpp
+++ b/include/spore/codegen/ast/parsers/ast_parser_clang.hpp
@@ -16,6 +16,7 @@
 #include "spore/codegen/codegen_options.hpp"
 #include "spore/codegen/misc/defer.hpp"
 #include "spore/codegen/utils/files.hpp"
+#include "spore/codegen/utils/strings.hpp"
 
 namespace spore::codegen
 {
@@ -261,6 +262,7 @@ namespace spore::codegen
                 }
             }
 
+            strings::trim_end(template_param.type, ",");
             return template_param;
         }
 

--- a/tests/t_ast_parser.cpp
+++ b/tests/t_ast_parser.cpp
@@ -39,7 +39,7 @@ TEMPLATE_TEST_CASE("spore::codegen::ast_parser", "[spore::codegen][spore::codege
 
     ast_file& ast_file = ast_files.at(0);
 
-    REQUIRE(ast_file.classes.size() == 7);
+    REQUIRE(ast_file.classes.size() == 8);
     REQUIRE(ast_file.functions.size() == 3);
     REQUIRE(ast_file.enums.size() == 2);
 
@@ -333,5 +333,26 @@ TEMPLATE_TEST_CASE("spore::codegen::ast_parser", "[spore::codegen][spore::codege
         REQUIRE(class_.template_params[4].name == "variadic_t");
         REQUIRE(class_.template_params[4].type == "typename...");
         REQUIRE(class_.template_params[4].is_variadic);
+    }
+
+    SECTION("parse unnamed template is feature complete")
+    {
+        ast_class& class_ = ast_file.classes[7];
+
+        REQUIRE(class_.name == "_unnamed_template");
+        REQUIRE(class_.template_params.size() == 5);
+        REQUIRE(class_.template_params[0].name == "_t0");
+        REQUIRE(class_.template_params[0].type == "typename");
+        REQUIRE(class_.template_params[1].name == "_t1");
+        REQUIRE(class_.template_params[1].type == "int");
+        REQUIRE(class_.template_params[2].name == "_t2");
+        REQUIRE(class_.template_params[2].type == "template <typename, typename, int> typename");
+        REQUIRE(class_.template_params[3].name == "_t3");
+        REQUIRE(class_.template_params[3].type == "concept_");
+
+        // TODO @sporacid Fix unnamed variadic templates
+        // REQUIRE(class_.template_params[4].name == "_t4");
+        // REQUIRE(class_.template_params[4].type == "typename...");
+        // REQUIRE(class_.template_params[4].is_variadic);
     }
 }

--- a/tests/t_ast_parser_input.hpp
+++ b/tests/t_ast_parser_input.hpp
@@ -93,3 +93,8 @@ template <typename value_t, int size_v, template <typename arg_t, typename, int>
 struct _template
 {
 };
+
+template <typename, int, template <typename, typename, int> typename, concept_, typename...>
+struct _unnamed_template
+{
+};


### PR DESCRIPTION
## Parser
- Fix unnamed template template parameters having a trailing comma in their name
- Fix unnamed variadic template parameters not having trailing dots in their name