### PR TITLE
fix: Fix caching issues with tools that rewrite identical files

### DIFF
--- a/.github/scripts/get_version.sh
+++ b/.github/scripts/get_version.sh
@@ -5,8 +5,14 @@ GIT_COMMITS=$(git --no-pager log --format=%H --reverse)
 MAJOR=1
 MINOR=0
 PATCH=0
+FIRST=0
 
 for GIT_COMMIT in $GIT_COMMITS; do
+  if [[ $FIRST -eq 0 ]]; then
+    FIRST=1
+    continue
+  fi
+
   GIT_MESSAGE=$(git --no-pager log -n1 --format=%B $GIT_COMMIT)
   if [[ "$GIT_MESSAGE" =~ "BREAKING CHANGES:" ]]; then
     # Major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,13 @@ jobs:
           sudo apt-get -qq update &&
           sudo apt-get install -y build-essential libtbb-dev ninja-build
       - name: Install LLVM
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: 17.0
-          env: true
-      - name: Export LLVM Environment
         run: |
-          echo "LLVM_DIR=${{ env.LLVM_PATH }}" >> $GITHUB_ENV &&
-          echo "CXXFLAGS=-isystem${{ env.LLVM_PATH }}/lib/clang/17/include" >> $GITHUB_ENV
+          wget https://apt.llvm.org/llvm.sh &&
+          chmod u+x llvm.sh &&
+          sudo ./llvm.sh 18 all &&
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-18 100 &&
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-18 100 &&
+          echo /usr/lib/llvm-18 >> $GITHUB_PATH
       - name: Install CMake
         uses: lukka/get-cmake@latest
       - name: Install Vcpkg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.17)
 
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0077 NEW)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ at [this repository](https://github.com/sporacid/spore-codegen-example) for a mo
 ### Windows
 
 1. Install `LLVM` from [GitHub releases](https://github.com/llvm/llvm-project/releases).
-2. Set `LLVM_DIR` environment variable to the `LLVM` install path.
+2. Add `LLVM` install path to `PATH` environment variable.
 3. Clone and set up `Vcpkg`:
    ```shell
    set VCPKG_DEFAULT_TRIPLET="x64-windows"
@@ -95,7 +95,6 @@ at [this repository](https://github.com/sporacid/spore-codegen-example) for a mo
    cd vcpkg
    ./bootstrap-vcpkg.bat
    set VCPKG_ROOT="%cd%"
-   set VCPKG_KEEP_ENV_VARS="LLVM_DIR"
    ```
 
 ### Ubuntu
@@ -103,8 +102,11 @@ at [this repository](https://github.com/sporacid/spore-codegen-example) for a mo
 1. Install `LLVM`:
 
    ```shell
-   sudo apt-get -qq update
-   sudo apt-get install llvm llvm-dev
+    export LLVM_VERSION=18
+    wget https://apt.llvm.org/llvm.sh
+    chmod u+x llvm.sh
+    sudo ./llvm.sh ${LLVM_VERSION} all
+    export PATH="$PATH:/usr/lib/llvm-${LLVM_VERSION}"
    ```
 
 2. Clone and set up `Vcpkg`:

--- a/cmake/FindClang.cmake
+++ b/cmake/FindClang.cmake
@@ -1,39 +1,18 @@
 include(FindPackageMessage)
 
-if (DEFINED LLVM_DIR)
-  set(_LLVM_DIR ${LLVM_DIR})
-elseif (DEFINED ENV{LLVM_DIR})
-  set(_LLVM_DIR $ENV{LLVM_DIR})
-endif ()
-
-if (DEFINED _LLVM_DIR)
-  set(
-    CLANG_LIBRARY_PATHS
-      ${_LLVM_DIR}/bin
-      ${_LLVM_DIR}/bin/clang
-      ${_LLVM_DIR}/lib
-      ${_LLVM_DIR}/lib/clang
-  )
-
-  set(
-    CLANG_INCLUDE_PATHS
-      ${_LLVM_DIR}/include
-  )
-endif ()
-
 find_file(
   CLANG_LIBRARIES
   NAMES
     libclang.lib
     libclang.a
     libclang.so
-  PATHS ${CLANG_LIBRARY_PATHS}
+  PATH_SUFFIXES bin lib
 )
 
 find_path(
   CLANG_INCLUDE_DIRS
   NAMES clang-c
-  PATHS ${CLANG_INCLUDE_PATHS}
+  PATH_SUFFIXES include
 )
 
 if (CLANG_LIBRARIES AND CLANG_INCLUDE_DIRS)
@@ -45,17 +24,9 @@ if (CLANG_LIBRARIES AND CLANG_INCLUDE_DIRS)
   )
 else ()
   set(CLANG_FOUND FALSE)
-  if (CLANG_REQUIRED)
+  if (Clang_FIND_REQUIRED)
     message(FATAL_ERROR "Clang was not found")
   else ()
-    find_package_message(
-      Clang
-      "Clang was not found, directory=${_LLVM_DIR}"
-      "[${_LLVM_DIR}]"
-    )
+    find_package_message(Clang "Clang was not found")
   endif ()
 endif ()
-
-unset(_LLVM_DIR)
-unset(CLANG_LIBRARY_PATHS)
-unset(CLANG_INCLUDE_PATHS)

--- a/cmake/FindClangFormat.cmake
+++ b/cmake/FindClangFormat.cmake
@@ -1,22 +1,9 @@
 include(FindPackageMessage)
 
-if (DEFINED LLVM_DIR)
-  set(_LLVM_DIR ${LLVM_DIR})
-elseif (DEFINED ENV{LLVM_DIR})
-  set(_LLVM_DIR $ENV{LLVM_DIR})
-endif ()
-
-if (DEFINED _LLVM_DIR)
-  set(
-    CLANG_EXECUTABLE_PATHS
-      ${_LLVM_DIR}/bin
-  )
-endif ()
-
 find_program(
   CLANG_FORMAT_EXECUTABLE
   NAMES clang-format
-  PATHS ${CLANG_EXECUTABLE_PATHS}
+  PATH_SUFFIXES bin
 )
 
 if (CLANG_FORMAT_EXECUTABLE)
@@ -28,16 +15,9 @@ if (CLANG_FORMAT_EXECUTABLE)
   )
 else ()
   set(CLANG_FORMAT_FOUND FALSE)
-  if (CLANG_FORMAT_REQUIRED)
+  if (ClangFormat_FIND_REQUIRED)
     message(FATAL_ERROR "Clang format was not found")
   else ()
-    find_package_message(
-      Clang
-      "Clang format was not found, directory=${_LLVM_DIR}"
-      "[${_LLVM_DIR}]"
-    )
+    find_package_message(Clang "Clang format was not found")
   endif ()
 endif ()
-
-unset(_LLVM_DIR)
-unset(CLANG_EXECUTABLE_PATHS)

--- a/examples/enum/codegen.yml
+++ b/examples/enum/codegen.yml
@@ -6,6 +6,6 @@ stages:
   parser: cpp
   steps:
   - name: enum
-    directory: include
+    directory: .codegen/include
     templates:
       - templates/enum.hpp.inja

--- a/examples/json/codegen.yml
+++ b/examples/json/codegen.yml
@@ -6,6 +6,6 @@ stages:
   parser: cpp
   steps:
   - name: json
-    directory: include
+    directory: .codegen/include
     templates:
       - templates/json.hpp.inja

--- a/include/spore/codegen/utils/files.hpp
+++ b/include/spore/codegen/utils/files.hpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "picosha2.h"
 
@@ -22,7 +23,7 @@ namespace spore::codegen::files
             yaml,
         };
 
-        inline json_file_type get_json_type(std::string_view path)
+        inline json_file_type get_json_type(const std::string_view path)
         {
             constexpr std::string_view json_exts[] {".json"};
             constexpr std::string_view bson_exts[] {".bson"};
@@ -36,12 +37,12 @@ namespace spore::codegen::files
                 return json_file_type::json;
             }
 
-            if (std::any_of(std::begin(bson_exts), std::end(bson_exts), predicate))
+            if (std::ranges::any_of(bson_exts, predicate))
             {
                 return json_file_type::bson;
             }
 
-            if (std::any_of(std::begin(yaml_exts), std::end(yaml_exts), predicate))
+            if (std::ranges::any_of(yaml_exts, predicate))
             {
                 return json_file_type::yaml;
             }
@@ -49,9 +50,9 @@ namespace spore::codegen::files
             return json_file_type::none;
         }
 
-        inline bool create_directories(std::string_view path)
+        inline bool create_directories(const std::string_view path)
         {
-            std::filesystem::path parent = std::filesystem::path(path).parent_path();
+            const std::filesystem::path parent = std::filesystem::path(path).parent_path();
 
             if (!parent.empty() && !std::filesystem::exists(parent) && !std::filesystem::create_directories(parent))
             {
@@ -62,7 +63,7 @@ namespace spore::codegen::files
         }
     }
 
-    inline bool write_file(std::string_view path, const std::string& content)
+    inline bool write_file(const std::string_view path, const std::string& content)
     {
         if (!detail::create_directories(path))
         {
@@ -75,7 +76,7 @@ namespace spore::codegen::files
         return !stream.bad();
     }
 
-    inline bool write_file(std::string_view path, const std::vector<std::uint8_t>& bytes)
+    inline bool write_file(const std::string_view path, const std::vector<std::uint8_t>& bytes)
     {
         if (!detail::create_directories(path))
         {
@@ -88,7 +89,7 @@ namespace spore::codegen::files
         return !stream.bad();
     }
 
-    inline bool write_file(std::string_view path, const nlohmann::json& json)
+    inline bool write_file(const std::string_view path, const nlohmann::json& json)
     {
         constexpr std::size_t indent = 2;
         switch (detail::get_json_type(path))
@@ -111,9 +112,9 @@ namespace spore::codegen::files
         }
     }
 
-    inline bool read_file(std::string_view path, std::string& content)
+    inline bool read_file(const std::string_view path, std::string& content)
     {
-        std::ifstream stream(path.data());
+        const std::ifstream stream(path.data());
         if (!stream.is_open())
         {
             return false;
@@ -125,7 +126,7 @@ namespace spore::codegen::files
         return !stream.bad();
     }
 
-    inline bool read_file(std::string_view path, std::vector<std::uint8_t>& bytes)
+    inline bool read_file(const std::string_view path, std::vector<std::uint8_t>& bytes)
     {
         std::ifstream stream(path.data(), std::ios::in | std::ios::binary);
         if (!stream.is_open())
@@ -142,7 +143,7 @@ namespace spore::codegen::files
         return !stream.bad();
     }
 
-    inline bool read_file(std::string_view path, nlohmann::json& json)
+    inline bool read_file(const std::string_view path, nlohmann::json& json)
     {
         json = nlohmann::json(nlohmann::json::value_t::discarded);
         switch (detail::get_json_type(path))
@@ -185,7 +186,7 @@ namespace spore::codegen::files
         return !json.is_discarded();
     }
 
-    inline bool hash_file(std::string_view path, std::string& hash)
+    inline bool hash_file(const std::string_view path, std::string& hash)
     {
         std::vector<std::uint8_t> data;
         if (!read_file(path, data))

--- a/include/spore/codegen/utils/json.hpp
+++ b/include/spore/codegen/utils/json.hpp
@@ -53,12 +53,12 @@ namespace spore::codegen::json
             property.insert(property.begin(), '/');
         }
 
-        nlohmann::json::json_pointer json_ptr {property};
+        const nlohmann::json::json_pointer json_ptr {property};
         return json.contains(json_ptr) && truthy(json[json_ptr]);
     }
 
     template <typename value_t>
-    bool get(const nlohmann::json& json, std::string_view key, value_t& value)
+    bool get(const nlohmann::json& json, const std::string_view key, value_t& value)
     {
         if (json.contains(key))
         {
@@ -79,7 +79,7 @@ namespace spore::codegen::json
     }
 
     template <typename value_t>
-    void get_checked(const nlohmann::json& json, std::string_view key, value_t& value, std::string_view context)
+    void get_checked(const nlohmann::json& json, std::string_view key, value_t& value, const std::string_view context)
     {
         if (!get(json, key, value)) [[unlikely]]
         {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,6 @@ target_include_directories(
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/thirdparty
     ${SPORE_PICOSHA2_INCLUDE_DIRS}
-    ${CLANG_INCLUDE_DIRS}
 )
 
 if (SPORE_WITH_CPP)


### PR DESCRIPTION
## Application
- Fix caching issue where identical files would trigger a generation because modification time was being used to check if the file changed
- Fix potential caching issue where entries are deserialized in an unsorted vector

## Parsers
- Refactor `C++` parser to take `CXCursor` and other semi-trivial `libclang` types by const ref

## Examples
- Fix output directory missing `.codegen`

## Build System
- Fix `get_version.sh` not starting correctly from `1.0.0` (no impact on current version number)
- Fix `libclang` libraries being linked despite `SPORE_WITH_CPP` being off
- Fix `FindClang.cmake` and `FindClangFormat.cmake` to rely on OS mechanism instead of `LLVM_DIR`