### PR TITLE
feat: add find_by callback and its doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Some additional functions have been added to the `inja` templating engine to sim
 | `truthy(any)`                     | `{% if truthy(class.attributes.json) %}{% endif %}`    | Evaluates whether a given value is truthy.                                                             |
 | `truthy(any, string)`             | `{% if truthy(class.attributes, "json") %}{% endif %}` | Evaluates whether a given value at the given path is truthy.                                           |
 | `contains(string, string)`        | `{{ contains(class.name, "_test") }}`                  | Checks whether a string contains a given substring.                                                    |
+| `find_by(array, string, string)`  | `{{ find_by(classes, "name", "MyClass") }}`            | Find an object in array with the desired key value. May be useful to get specified class.              |
 | `replace(string, string, string)` | `{{ replace(class.name, "_t", "_test") }}`             | Replaces a given substring within string with another given substring.                                 |
 | `format(string, ...)`             | `{{ format("{}: {}", key, value) }}`                   | Formats the given string with the given arguments. Follows `std::format` rules.                        |
 | `starts_with(string, string)`     | `{{ starts_with(class.name, "prefix_") }}`             | Checks whether a string starts with the given substring.                                               |


### PR DESCRIPTION
Add `find_by` callback and its documentation.

Not sure about exceptions in callback, check it, please.

I've been testing this with:

header:
```c
#pragma once

typedef struct Struct1 {
    int field1;
    char field2;
} Struct1;
```
template:
```inja
// Enumerate fields of desired Class 
{% for field in find_by(classes, "name", "Struct1").fields %}
    {{ field.name }}
{% endfor %}
```

result:

```
// Enumerate fields of desired Class 
    field1
    field2
```

**Exception case:**

template:
```inja
// Enumerate fields of desired Class 
{% for field in find_by(classes, "name", "Struct2").fields %}
    {{ field.name }}
{% endfor %}
```

Generation output:
```
info: parsing stage files, stage=headers parser=cpp files=[input.h] count=1
info: parsing completed, stage=headers duration=0.008s
info: rendering completed, stage=headers duration=0.003s
info: codegen completed, duration=0.015s
error: find_by: object not found
```