### PR TITLE
feat: add base_name and extent to type objects for c-style arrays support

### DIFF
--- a/include/spore/codegen/parsers/cpp/ast/cpp_ref.hpp
+++ b/include/spore/codegen/parsers/cpp/ast/cpp_ref.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "spore/codegen/parsers/cpp/ast/cpp_flags.hpp"
 
@@ -9,6 +10,8 @@ namespace spore::codegen
     struct cpp_ref : cpp_has_flags<cpp_ref>
     {
         std::string name;
+        std::string base_name;
+        std::vector<std::size_t> extent;
         bool is_variadic = false;
     };
 }

--- a/include/spore/codegen/parsers/cpp/codegen_converter_cpp.hpp
+++ b/include/spore/codegen/parsers/cpp/codegen_converter_cpp.hpp
@@ -70,6 +70,15 @@ namespace spore::codegen
         to_json(json, static_cast<const cpp_has_flags<cpp_ref>&>(value));
 
         json["name"] = value.name;
+        json["base_name"] = value.base_name;
+        if (value.extent.size() == 1)
+        {
+            json["extent"] = value.extent.at(0);
+        }
+        else if (value.extent.size() > 1)
+        {
+            json["extent"] = value.extent;
+        }
     }
 
     inline void to_json(nlohmann::json& json, const cpp_template_param_kind value)

--- a/src/lib/codegen_parser_cpp.cpp
+++ b/src/lib/codegen_parser_cpp.cpp
@@ -290,6 +290,19 @@ namespace spore::codegen
                 cpp_ref.flags = cpp_ref.flags | cpp_flags::volatile_;
             }
 
+            auto array_type = llvm::dyn_cast<clang::ConstantArrayType>(type.getTypePtr());
+            while (array_type)
+            {
+                cpp_ref.base_name = array_type->getElementType().getAsString();
+                cpp_ref.extent.push_back(array_type->getSize().getZExtValue());
+                array_type = llvm::dyn_cast<clang::ConstantArrayType>(array_type->getElementType().getTypePtr());
+            }
+
+            if (cpp_ref.extent.empty())
+            {
+                cpp_ref.base_name = cpp_ref.name;
+            }
+
             return cpp_ref;
         }
 

--- a/tests/t_codegen_parser_cpp.cpp
+++ b/tests/t_codegen_parser_cpp.cpp
@@ -35,7 +35,7 @@ TEST_CASE("spore::codegen::codegen_parser_cpp", "[spore::codegen][spore::codegen
     REQUIRE(cpp_file.classes.size() == 14);
     REQUIRE(cpp_file.functions.size() == 3);
     REQUIRE(cpp_file.enums.size() == 2);
-    REQUIRE(cpp_file.variables.size() == 9);
+    REQUIRE(cpp_file.variables.size() == 12);
 
     SECTION("parse enum is feature complete")
     {
@@ -90,7 +90,7 @@ TEST_CASE("spore::codegen::codegen_parser_cpp", "[spore::codegen][spore::codegen
 
         SECTION("parse class field is feature complete")
         {
-            REQUIRE(class_.fields.size() == 2);
+            REQUIRE(class_.fields.size() == 3);
 
             REQUIRE(class_.fields[0].name == "_i");
             REQUIRE(class_.fields[0].type.name == "int");
@@ -101,6 +101,11 @@ TEST_CASE("spore::codegen::codegen_parser_cpp", "[spore::codegen][spore::codegen
 
             REQUIRE(class_.fields[1].name == "_f");
             REQUIRE(class_.fields[1].type.name == "float");
+
+            REQUIRE(class_.fields[2].name == "_array_field");
+            REQUIRE(class_.fields[2].type.name == "char[4]");
+            REQUIRE(class_.fields[2].type.base_name == "char");
+            REQUIRE(class_.fields[2].type.extent.at(0) == 4);
         }
 
         SECTION("parse class constructor is feature complete")
@@ -547,5 +552,35 @@ TEST_CASE("spore::codegen::codegen_parser_cpp", "[spore::codegen][spore::codegen
         REQUIRE(var8.template_specialization_params[0] == "int");
         REQUIRE(var8.default_value.has_value());
         REQUIRE(var8.default_value.value() == "42");
+
+        cpp_variable var9 = cpp_file.variables[9];
+        REQUIRE(var9.name == "_array_var");
+        REQUIRE(var9.default_value.has_value());
+        REQUIRE(var9.default_value.value() == "{0, 1, 2, 3}");
+        REQUIRE(var9.type.name == "char[4]");
+        REQUIRE(var9.type.base_name == "char");
+        REQUIRE(var9.type.extent.size() == 1);
+        REQUIRE(var9.type.extent.at(0) == 4);
+
+        cpp_variable var10 = cpp_file.variables[10];
+        REQUIRE(var10.name == "_2d_array_var");
+        REQUIRE(var10.default_value.has_value());
+        REQUIRE(var10.default_value.value() == "{{0, 1}, {2, 3}, {4, 5}}");
+        REQUIRE(var10.type.name == "char[3][2]");
+        REQUIRE(var10.type.base_name == "char");
+        REQUIRE(var10.type.extent.size() == 2);
+        REQUIRE(var10.type.extent.at(0) == 3);
+        REQUIRE(var10.type.extent.at(1) == 2);
+
+        cpp_variable var11 = cpp_file.variables[11];
+        REQUIRE(var11.name == "_3d_array_var");
+        REQUIRE(var11.default_value.has_value());
+        REQUIRE(var11.default_value.value() == "{{{0, 1}, {2, 3}}, {{4, 5}, {6, 7}}}");
+        REQUIRE(var11.type.name == "char[2][2][2]");
+        REQUIRE(var11.type.base_name == "char");
+        REQUIRE(var11.type.extent.size() == 3);
+        REQUIRE(var11.type.extent.at(0) == 2);
+        REQUIRE(var11.type.extent.at(1) == 2);
+        REQUIRE(var11.type.extent.at(2) == 2);
     }
 }

--- a/tests/t_codegen_parser_cpp_data.hpp
+++ b/tests/t_codegen_parser_cpp_data.hpp
@@ -19,6 +19,7 @@ namespace _namespace1::_namespace2
         ATTRIBUTE(_field)
         int _i = 42;
         float _f;
+        char _array_field[4];
 
         ATTRIBUTE(_constructor)
         _struct() = default;
@@ -166,3 +167,7 @@ value_t _template_var {};
 
 template <>
 int _template_var<int> = 42;
+
+char _array_var[4] = {0, 1, 2, 3};
+char _2d_array_var[3][2] = {{0, 1}, {2, 3}, {4, 5}};
+char _3d_array_var[2][2][2] = {{{0, 1}, {2, 3}}, {{4, 5}, {6, 7}}};


### PR DESCRIPTION
Add `base_name` and `size` to `cpp_ref` struct and to json type objects.  
For arrays these fields will be as follows: `base_name` is the type of array element, `size` is the size of array.  
For non-array types these fields will be as follows: `base_name` is equal to `name`, size is zero.

Add test for the c-style arrays.