### PR TITLE
feat: add regex_match regex_search funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ Some additional functions have been added to the `inja` templating engine to sim
 | `truthy(any)`                     | `{% if truthy(class.attributes.json) %}{% endif %}`    | Evaluates whether a given value is truthy.                                                             |
 | `truthy(any, string)`             | `{% if truthy(class.attributes, "json") %}{% endif %}` | Evaluates whether a given value at the given path is truthy.                                           |
 | `contains(string, string)`        | `{{ contains(class.name, "_test") }}`                  | Checks whether a string contains a given substring.                                                    |
+| `regex_match(string, string)`     | `{{ regex_match("Hello123", "^[A-Za-z]+\\d+") }}`      | Check if the input string matches a format. Follows `std::regex_match` rules.                          |
+| `regex_search(string, string)`    | `{{ regex_search("Hello123 ABC", "^[A-Za-z]+\\d+") }}` | Search for character groups by format. Follows `std::regex_search` rules.                              |
 | `find_by(array, string, string)`  | `{{ find_by(classes, "name", "MyClass") }}`            | Find an object in array with the desired key value. May be useful to get specified class.              |
 | `replace(string, string, string)` | `{{ replace(class.name, "_t", "_test") }}`             | Replaces a given substring within string with another given substring.                                 |
 | `format(string, ...)`             | `{{ format("{}: {}", key, value) }}`                   | Formats the given string with the given arguments. Follows `std::format` rules.                        |

--- a/include/spore/codegen/renderers/codegen_renderer_inja.hpp
+++ b/include/spore/codegen/renderers/codegen_renderer_inja.hpp
@@ -208,6 +208,27 @@ namespace spore::codegen
                     return value.find(str) != std::string::npos;
                 });
 
+            inja_env.add_callback("regex_match", 2,
+                [](const inja::Arguments& args) {
+                    const std::string& input = args.at(0)->get<std::string>();
+                    const std::string& regex = args.at(1)->get<std::string>();
+
+                    return strings::regex_match(input, regex);
+                });
+
+            inja_env.add_callback("regex_search", 2,
+                [](const inja::Arguments& args) {
+                    const std::string& input = args.at(0)->get<std::string>();
+                    const std::string& regex = args.at(1)->get<std::string>();
+                    nlohmann::json json = nlohmann::json::array();
+
+                    strings::for_each_by_regex(input, regex, [&](const std::string_view match) {
+                        json.push_back(match);
+                    });
+
+                    return json;
+                });
+
             inja_env.add_callback("find_by", 3,
                 [](const inja::Arguments& args) {
                     const nlohmann::json& json = *args.at(0);

--- a/include/spore/codegen/utils/strings.hpp
+++ b/include/spore/codegen/utils/strings.hpp
@@ -4,6 +4,7 @@
 #include <format>
 #include <functional>
 #include <optional>
+#include <regex>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -212,6 +213,28 @@ namespace spore::codegen::strings
     inline std::string to_sentence_case(const std::string_view input)
     {
         return detail::to_any_case(input, " ", detail::toupper, detail::tolower, detail::tolower);
+    }
+
+    inline bool regex_match(const std::string_view input, const std::string_view regex)
+    {
+        const std::regex pattern(regex.cbegin(), regex.cend());
+        return std::regex_match(input.cbegin(), input.cend(), pattern);
+    }
+
+    template <typename callback_t>
+    void for_each_by_regex(const std::string_view input, const std::string_view regex, const callback_t&& callback)
+    {
+        const std::regex pattern(regex.cbegin(), regex.cend());
+        std::match_results<std::string_view::const_iterator> matches {};
+
+        if (std::regex_search(input.cbegin(), input.cend(), matches, pattern))
+        {
+            for (auto it = matches.cbegin() + 1; it < matches.cend(); ++it)
+            {
+                const auto match_view = std::string_view(it->first, it->length());
+                callback(match_view);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Forward `std::regex_match`, `std::regex_search` funcs to inja callbacks.

**Match example:**

```jinja
{{regex_match("Hello123", "^[A-Za-z]+\\d+")}}
```
->
```
true
```

**Search example:**

```jinja
{{regex_search("Hello123 ABC", "([A-Za-z]+)(\\d+)")}}
```
->
```
["Hello","123"]
```

This PR is related with https://github.com/sporacid/spore-codegen/issues/95.